### PR TITLE
first try on ParticlePositioner

### DIFF
--- a/examples/populate_abacus.py
+++ b/examples/populate_abacus.py
@@ -1,0 +1,75 @@
+import numpy as np
+from pycorr import TwoPointCorrelationFunction, setup_logging
+from pymocker.catalogues import HaloCatalogue
+from pymocker.populator import Populator
+from pymocker.galaxy import VanillaGalaxy, AemulusGalaxy
+from pymocker.sampler import Sampler
+from pymocker.occupation import Zheng07Centrals, Zheng07Sats
+from pymocker.positioners import IdentityPositioner, NFWPositioner, ParticlePositioner
+from hmd.concentration import diemer15
+from astropy.cosmology import Planck18
+import matplotlib.pyplot as plt
+
+
+setup_logging()
+
+halo_cat = HaloCatalogue.from_abacus(
+    node=0, phase=3000, redshift=0.2, boxsize=500,
+    include_particles=True)
+
+# halo_cat.concentration = diemer15(
+#     prim_haloprop=halo_cat.mass,
+#     redshift=0.575,
+#     cosmology=Planck18,
+#     sigma8=0.8,
+#     allow_tabulation=True
+# )
+
+central_sampler = Sampler(
+    occupation=Zheng07Centrals(),
+    positioner=IdentityPositioner(),
+)
+sat_sampler = Sampler(
+    occupation=Zheng07Sats(),
+    positioner=ParticlePositioner(),
+)
+populator = Populator(
+    central_sampler=central_sampler,
+    satellite_sampler=sat_sampler,
+)
+galaxy = VanillaGalaxy(
+    log_M_min = 13.,
+    sigma_log_M = 0.5,
+    kappa = 0.5,
+    log_M1=13.,
+    alpha=1.,
+)
+gal_cat = populator(halo_cat=halo_cat, galaxy=galaxy)
+
+# edges = (np.logspace(-1, np.log10(50), 51),
+#     np.linspace(-1., 1., 201))
+
+# gals_result = TwoPointCorrelationFunction(
+#     'smu', edges, data_positions1=gal_cat.pos.T,
+#      engine='corrfunc', boxsize=gal_cat.boxsize,
+#      los='z', nthreads=256
+# )
+# halos_result = TwoPointCorrelationFunction(
+#     'smu', edges, data_positions1=halo_cat.pos.T,
+#      engine='corrfunc', boxsize=gal_cat.boxsize,
+#      los='z', nthreads=256
+# )
+
+
+# fig, ax = plt.subplots()
+# s, multipoles_gals = gals_result(ells=(0, 2), return_sep=True)
+# s, multipoles_halos = halos_result(ells=(0, 2), return_sep=True)
+
+# ax.loglog(s, multipoles_gals[0], label='galaxies')
+# ax.loglog(s, multipoles_halos[0], label='halos')
+
+# ax.set_xlabel(r'$s\,[h^{-1}{\rm Mpc}]$')
+# ax.set_ylabel(r'$\xi_0(s)$')
+# ax.legend()
+
+# plt.savefig('test.png', dpi=300)

--- a/pymocker/catalogues/read_utils.py
+++ b/pymocker/catalogues/read_utils.py
@@ -199,6 +199,5 @@ def get_abacus_params(node: int)->Dict[str, float]:
     param_df.columns = param_df.columns.str.strip()
     param_df = param_df.apply(lambda x: x.str.strip() if x.dtype == "object" else x)
     idx = param_df.index[param_df['root'] == f'abacus_cosm{node:03}'][0]
-    param_df = param_df.drop(columns=['A_s', 'N_ur', 'N_ncdm',
-        'omega_ncdm', 'sigma8_cb', 'notes', 'root'])
+    param_df = param_df.drop(columns=['notes', 'root'])
     return param_df.to_dict('records')[idx]

--- a/pymocker/occupation.py
+++ b/pymocker/occupation.py
@@ -133,6 +133,7 @@ class AemulusSatellites(Zheng07Sats):
         Returns:
             np.array: lambda value
         """
+        print(galaxy.M_cut)
         return (halo_mass / galaxy.M_sat) ** galaxy.alpha * np.exp(
             -galaxy.M_cut / halo_mass
         )

--- a/pymocker/positioners.py
+++ b/pymocker/positioners.py
@@ -153,3 +153,26 @@ class NFWPositioner(Positioner):
             axis=0,
         )
         return halo_pos + np.vstack((delta_x, delta_y, delta_z)).T
+
+
+class ParticlePositioner(Positioner):
+    def get_pos(self, halo_cat: HaloCatalogue, n_tracers_per_halo: np.array,
+        seed: int = 42) -> np.array:
+        """Sample tracers using dark matter particle positions within
+        haloes
+
+        Args:
+            halo_cat (HaloCatalogue): halo catalogue to be populated
+            n_tracers_per_halo (np.array[int]): number of tracers to draw for each halo
+
+        Returns:
+            np.array[float]: positions of the desired tracers
+        """
+
+        np.random.seed(seed)
+        pos = []
+        for i in range(len(halo_cat)):
+            pos_i = halo_cat.dm_pos[halo_cat.npstart[i]:halo_cat.npstart[i] + halo_cat.npout[i]]
+            idx = np.random.randint(len(pos_i), size=n_tracers_per_halo[i])
+            pos.append(pos_i[idx])
+        return np.asarray(pos)


### PR DESCRIPTION
A first approach to implementing the ParticlePositioner for satellites. It should work in principle, but it's just too slow for practical purposes. 

Reading the subsampled DM positions for each halo from the AbacusSummit catalogues is pretty fast. The slow part is the further random subsampling of the DM positions according to n_tracers_per_halo, line #175 of positioners.py. If you put a print statement inside the loop and run the populate_abacus.py example, you will see that it takes forever to loop through all the haloes.

This is just a basic implementation, I would guess there are several ways to improve it. For starters, we could try to do this using array broadcasting instead of calling np.random.randint at each iteration (haven't cracked how do do this yet though). Maybe you can also add some jaxxx to it and make it even faster!!